### PR TITLE
Address feedback from JelleZijlstra

### DIFF
--- a/pep-0705.rst
+++ b/pep-0705.rst
@@ -2,7 +2,7 @@ PEP: 705
 Title: TypedMapping: Type Hints for Mappings with a Fixed Set of Keys
 Author: Alice Purcell <alicederyn@gmail.com>
 Sponsor: Pablo Galindo <pablogsal@gmail.com>
-Discussions-To: https://mail.python.org/archives/list/python-dev@python.org/thread/2P26R4VH2ZCNNNOQCBZWEM4RNF35OXOW/
+Discussions-To: pending
 Status: Draft
 Type: Standards Track
 Topic: Typing
@@ -93,14 +93,22 @@ Finally, this allows bringing the benefits of ``TypedDict`` to other mapping typ
 Specification
 =============
 
-The ``TypedMapping`` type is a protocol behaving almost identically to ``TypedDict``, except:
+A ``TypedMapping`` type defines a protocol with the same methods as :class:`~collections.abc.Mapping`, but with value types determined per-key as with ``TypedDict``.
 
-* The runtime type of a ``TypedMapping`` object is not constrained to be a ``dict``
-* No mutator methods (``__setitem__``, ``__delitem__``, ``update``, etc.) will be generated
-* A class definition defines a ``TypedMapping`` protocol if and only if ``TypedMapping`` appears directly in its class bases
-* Subclasses can narrow field types, in the same manner as other protocols
+Notable similarities to ``TypedDict``:
 
-All current and future features of ``TypedDict`` are applicable to ``TypedMapping``, including class-based and alternative syntax, totality, and ``Required``/``NotRequired`` from :pep:`655`.
+* A ``TypedMapping`` protocol can be declared using class-based or alternative syntax.
+* Keys must be strings.
+* By default, all specified keys must be present in a ``TypedMapping`` instance. It is posible to override this by specifying totality, or by using ``NotRequired`` from :pep:`655`.
+* Methods are not allowed in the declaration (though they may be inherited).
+
+Notable differences from ``TypedDict``:
+
+* The runtime type of a ``TypedMapping`` object is not constrained to be a ``dict``.
+* No mutator methods (``__setitem__``, ``__delitem__``, ``update``, etc.) will be generated.
+* The ``|`` operator is not supported.
+* A class definition defines a ``TypedMapping`` protocol if and only if ``TypedMapping`` appears directly in its class bases.
+* Subclasses can narrow value types, in the same manner as other protocols.
 
 As with :pep:`589`, this PEP provides a sketch of how a type checker is expected to support type checking operations involving ``TypedMapping`` and ``TypedDict`` objects, but details are left to implementors. In particular, type compatibility should be based on structural compatibility.
 


### PR DESCRIPTION
Define what TypedMapping does support, not just what it doesn't, to clarify edge cases like ``|``.