### PR TITLE
Address Jelle's feedback

### DIFF
--- a/pep-0705.rst
+++ b/pep-0705.rst
@@ -250,12 +250,7 @@ overloads), so code that inspects ``TypedDict`` types will have to change. This
 is expected to mainly affect type-checkers.
 
 The ``TypedMapping`` type will be added to the ``typing_extensions`` module,
-enabling its use in older versions of Python. Users wanting to inherit from
-both ``TypedDict`` and ``TypedMapping`` will need to use
-``typing_extensions.TypedDict`` in these versions, as the existing ``typing`` implementation
-of ``TypedDict`` does an ``is`` check on the metaclass of all base classes and raises
-an error if any other metaclass is found. This would cause any subclass of both
-that implementation and a ``TypedMapping`` protocol to trigger an error at runtime.
+enabling its use in older versions of Python.
 
 
 Security Implications

--- a/pep-0705.rst
+++ b/pep-0705.rst
@@ -262,12 +262,12 @@ There are no known security consequences arising from this PEP.
 How to Teach This
 =================
 
-This PEP should be linked in the :mod:`typing` module's documentation.
-Class documentation should also be added, using that for
-:class:`~collections.abc.Mapping`, :class:`~typing.Protocol` and
-:class:`~typing.TypedDict` as examples.
+Class documentation should be added to the :mod:`typing` module's documentation, using
+that for :class:`~collections.abc.Mapping`, :class:`~typing.Protocol` and
+:class:`~typing.TypedDict` as examples. Suggested introductory sentence: "Base class
+for read-only mapping protocol classes."
 
-Suggested introductory sentence: "Base class for read-only mapping protocol classes."
+This PEP can be added to the others listed in the :mod:`typing` module's documentation.
 
 
 Reference Implementation


### PR DESCRIPTION
Address feedback from @JelleZijlstra:

* Remove `typing_extensions` implementation details; this is more than is necessary for the PEP.
* Do not _mandate_ adding the PEP to the `typing` module docs, in case that practice ends before the PEP lands. Left in as a suggestion to mirror [PEP 692].

[PEP 692]: https://peps.python.org/pep-0692/